### PR TITLE
Feature/follow: 유저 팔로우 & 팔로우 취소 기능 구현

### DIFF
--- a/src/follow/index.tsx
+++ b/src/follow/index.tsx
@@ -1,0 +1,67 @@
+/**
+ * 현재 unFollow 기능이 정상적으로 작동하지 않습니다.
+ */
+import axios from 'axios';
+
+const END_POINT = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
+const followed = '63be4d1dad5c5114f90103e5'; // 팔로우 당하는 계정 id
+const following = '63be4d05ad5c5114f90103ca'; // 팔로우 하는 계정 id
+
+interface temp {
+  user: string;
+}
+
+const Follow = () => {
+  const token = localStorage.getItem('TOKEN_KEY'); // 팔로우 하는 계정 token
+
+  const body = {
+    _id: followed,
+  };
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `bearer ${token}`,
+  };
+
+  const handleOnClickFollow = () => {
+    axios.get(`${END_POINT}/auth-user`, { headers }).then((res) => {
+      const { data } = res;
+      let check = true;
+
+      if (data.following.find(({ user }: temp) => user === followed)) check = false;
+
+      if (check) {
+        axios
+          .post(`${END_POINT}/follow/create`, body, { headers })
+          .then((res) => console.log(res.data))
+          .catch((e) => console.log(e));
+      }
+    });
+  };
+
+  // UnFollow 기능이 정상적으로 작동하지 않습니다.
+  const handleOnClickUnFollow = () => {
+    axios.post(`${END_POINT}/login`, { email: 'following', password: '123' }).then((res) => {
+      const { data } = res;
+      const temp = data.user.following.find((i: any) => i.user === followed);
+      console.log({ ...temp });
+
+      axios
+        .delete(`${END_POINT}/follow/delete`, {
+          data: { id: '63be4d1dad5c5114f90103e5' }, // 팔로우 당하는 계정.
+          headers,
+        })
+        .then((res) => console.log(res))
+        .catch((e) => console.log(e));
+    });
+  };
+
+  return (
+    <div>
+      <h1>Follow TEST</h1>
+      <button onClick={handleOnClickFollow}>팔로우 하기</button>
+      <button onClick={handleOnClickUnFollow}>팔로우 취소 하기</button>
+    </div>
+  );
+};
+
+export default Follow;

--- a/src/follow/index.tsx
+++ b/src/follow/index.tsx
@@ -1,6 +1,3 @@
-/**
- * 현재 unFollow 기능이 정상적으로 작동하지 않습니다.
- */
 import axios from 'axios';
 
 const END_POINT = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
@@ -14,9 +11,6 @@ interface temp {
 const Follow = () => {
   const token = localStorage.getItem('TOKEN_KEY'); // 팔로우 하는 계정 token
 
-  const body = {
-    _id: followed,
-  };
   const headers = {
     'Content-Type': 'application/json',
     Authorization: `bearer ${token}`,
@@ -25,33 +19,40 @@ const Follow = () => {
   const handleOnClickFollow = () => {
     axios.get(`${END_POINT}/auth-user`, { headers }).then((res) => {
       const { data } = res;
-      let check = true;
 
-      if (data.following.find(({ user }: temp) => user === followed)) check = false;
+      const target = data.following.find(({ user }: temp) => user === followed);
 
-      if (check) {
+      if (!target) {
         axios
-          .post(`${END_POINT}/follow/create`, body, { headers })
+          .post(`${END_POINT}/follow/create`, { id: followed }, { headers })
           .then((res) => console.log(res.data))
           .catch((e) => console.log(e));
       }
     });
   };
 
-  // UnFollow 기능이 정상적으로 작동하지 않습니다.
+  /**
+   * 계정 정보를 받아온다.
+   * 내가 언팔할 유저의 정보가 following에 있는지 찾는다.
+   * 있다면 해당 'follow'의 'id'를 delete 요청으로 삭제한다.
+   */
   const handleOnClickUnFollow = () => {
-    axios.post(`${END_POINT}/login`, { email: 'following', password: '123' }).then((res) => {
+    axios.get(`${END_POINT}/auth-user`, { headers }).then((res) => {
       const { data } = res;
-      const temp = data.user.following.find((i: any) => i.user === followed);
-      console.log({ ...temp });
 
-      axios
-        .delete(`${END_POINT}/follow/delete`, {
-          data: { id: '63be4d1dad5c5114f90103e5' }, // 팔로우 당하는 계정.
-          headers,
-        })
-        .then((res) => console.log(res))
-        .catch((e) => console.log(e));
+      const target = data.following.find(({ user }: temp) => user === followed);
+
+      if (target) {
+        axios
+          .delete(`${END_POINT}/follow/delete`, {
+            data: {
+              id: target._id,
+            },
+            headers,
+          })
+          .then((res) => console.log(res))
+          .catch((e) => console.log(e));
+      }
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,7 +2643,7 @@ axe-core@^4.4.3:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.6.2.tgz"
   integrity sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg==
 
-axios@^1.2.2:
+axios@*, axios@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.2.tgz#72681724c6e6a43a9fea860fc558127dbe32f9f1"
   integrity sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가


<br/>

## 📑 작업리스트

> 작업한 목록

- 유저를 팔로우 할 수 있습니다.
- 유저를 언 팔로우 할 수 있습니다.

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항

현재 서버에서 중복 팔로우를 처리해주는 기능이 없습니다. 
그래서 인증확인(GET /auth-user)를 거친 뒤 find를 통해서 이미 팔로우 중인지 확인 후 팔로우 중이 아니라면 팔로우 요청을 보내게 되어있습니다.
즉 2번의 API 호출이 필요합니다.
언팔로우 역시 마찬가지 입니다.

해당 부분에 관해서 API호출을 줄일 수 있는 방법을 생각해 봐야합니다.
