### PR TITLE
Feature/userImg: 프로필 이미지, 커버 이미지 수정 기능 구현

### DIFF
--- a/src/user/UserEdit.tsx
+++ b/src/user/UserEdit.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { useNavigate, useParams } from 'react-router-dom';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import UserEditImg from './UserEditImg';
 
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 const TOKEN = localStorage.getItem('token');
@@ -53,8 +54,7 @@ const UserEdit = () => {
   };
   return (
     <>
-      <div>커버이미지</div>
-      <div>프로필 이미지</div>
+      <UserEditImg />
       <form onSubmit={handleSubmit(handleChangeUserInfo)}>
         <input
           type='text'

--- a/src/user/UserEdit.tsx
+++ b/src/user/UserEdit.tsx
@@ -8,7 +8,7 @@ const TOKEN = localStorage.getItem('token');
 const headers = {
   Authorization: `bearer ${TOKEN}`,
 };
-const id = '63bbb8d08c65a93bebe29f78';
+
 interface IFormValue {
   fullName: string;
   password: string;
@@ -16,7 +16,7 @@ interface IFormValue {
 
 const UserEdit = () => {
   const navigate = useNavigate();
-  // const { id } = useParams();
+  const { id } = useParams();
   const {
     register,
     handleSubmit,

--- a/src/user/UserEdit.tsx
+++ b/src/user/UserEdit.tsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import UserEditImg from './UserEditImg';
@@ -15,12 +16,14 @@ interface IFormValue {
 }
 
 const UserEdit = () => {
-  const navigate = useNavigate();
   const { id } = useParams();
+  const [imgFiles, setimgFiles] = useState({});
+  const navigate = useNavigate();
+
   const {
     register,
     handleSubmit,
-    formState: { errors, dirtyFields },
+    formState: { errors, dirtyFields, isSubmitting },
   } = useForm<IFormValue>({
     defaultValues: () =>
       axios.get(`${API_URL}/users/${id}`).then(({ data }) => {
@@ -31,11 +34,21 @@ const UserEdit = () => {
       }),
   });
 
-  const handleChangeUserInfo: SubmitHandler<IFormValue> = ({ fullName, password }) => {
-    if (dirtyFields.fullName) getChangeUserName(fullName);
-    if (dirtyFields.password) getChangePassword(password);
+  const handleChangeUserInfo: SubmitHandler<IFormValue> = async ({ fullName, password }) => {
+    if (dirtyFields.fullName) await getChangeUserName(fullName);
+    if (dirtyFields.password) await getChangePassword(password);
+
+    for (const formdata of Object.values(imgFiles)) {
+      if (formdata instanceof FormData) {
+        await getChangeImg(formdata);
+      }
+    }
 
     navigate(`/user/${id}`);
+  };
+
+  const getChangeImg = async (formdata: FormData) => {
+    await axios.post(`${API_URL}/users/upload-photo`, formdata, { headers });
   };
 
   const getChangePassword = async (password: string) => {
@@ -52,9 +65,10 @@ const UserEdit = () => {
       { headers }
     );
   };
+
   return (
     <>
-      <UserEditImg id={id} />
+      <UserEditImg id={id} setimgFiles={setimgFiles} />
       <form onSubmit={handleSubmit(handleChangeUserInfo)}>
         <input
           type='text'
@@ -76,7 +90,9 @@ const UserEdit = () => {
           })}
         />
         <span>{errors?.password?.message}</span>
-        <button type='submit'>저장</button>
+        <button type='submit' disabled={isSubmitting}>
+          저장
+        </button>
       </form>
     </>
   );

--- a/src/user/UserEdit.tsx
+++ b/src/user/UserEdit.tsx
@@ -8,7 +8,7 @@ const TOKEN = localStorage.getItem('token');
 const headers = {
   Authorization: `bearer ${TOKEN}`,
 };
-
+const id = '63bbb8d08c65a93bebe29f78';
 interface IFormValue {
   fullName: string;
   password: string;
@@ -16,7 +16,7 @@ interface IFormValue {
 
 const UserEdit = () => {
   const navigate = useNavigate();
-  const { id } = useParams();
+  // const { id } = useParams();
   const {
     register,
     handleSubmit,
@@ -54,7 +54,7 @@ const UserEdit = () => {
   };
   return (
     <>
-      <UserEditImg />
+      <UserEditImg id={id} />
       <form onSubmit={handleSubmit(handleChangeUserInfo)}>
         <input
           type='text'

--- a/src/user/UserEditImg.tsx
+++ b/src/user/UserEditImg.tsx
@@ -1,0 +1,68 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+const COVER_IMG_URL = 'https://ifh.cc/g/ZSypny.png';
+const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+
+const UserEditImg = () => {
+  const [profileImage, setProfileImage] = useState(PROFIE_IMG_URL);
+  const [coverImage, setCoverImage] = useState(COVER_IMG_URL);
+  const profileInputRef = useRef<HTMLInputElement>(null);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  const handleChangeImg = (e: React.ChangeEvent<HTMLInputElement>, type: string) => {
+    if (e.currentTarget.files !== null) {
+      const file = e.currentTarget.files[0];
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (reader.readyState === 2) {
+          type === 'profile'
+            ? setProfileImage(reader.result as string)
+            : setCoverImage(reader.result as string);
+        }
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <CoverImg src={coverImage} onClick={() => coverInputRef.current?.click()} />
+      <ProfileImg src={profileImage} onClick={() => profileInputRef.current?.click()} />
+      <input
+        type='file'
+        style={{ display: 'none' }}
+        accept='image/jpg,impge/png,image/jpeg'
+        name='profile_img'
+        onChange={(e) => handleChangeImg(e, 'profile')}
+        ref={profileInputRef}
+      />
+      <input
+        type='file'
+        style={{ display: 'none' }}
+        accept='image/jpg,impge/png,image/jpeg'
+        name='cover_img'
+        onChange={(e) => handleChangeImg(e, 'cover')}
+        ref={coverInputRef}
+      />
+    </Wrapper>
+  );
+};
+
+export default UserEditImg;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const CoverImg = styled.img`
+  width: 400px;
+  height: 200px;
+`;
+
+const ProfileImg = styled.img`
+  border-radius: 50%;
+  width: 80px;
+`;

--- a/src/user/UserEditImg.tsx
+++ b/src/user/UserEditImg.tsx
@@ -13,7 +13,7 @@ const headers = {
   'Content-Type': 'multipart/form-data',
 };
 interface IProps {
-  id: string;
+  id: string | undefined;
 }
 
 const UserEditImg = ({ id }: IProps) => {
@@ -38,7 +38,7 @@ const UserEditImg = ({ id }: IProps) => {
 
       const reader = new FileReader();
       reader.readAsDataURL(file);
-      reader.onload = async () => {
+      reader.onload = () => {
         if (reader.readyState === 2) {
           type === 'profile'
             ? setProfileImage(reader.result as string)
@@ -47,10 +47,10 @@ const UserEditImg = ({ id }: IProps) => {
       };
 
       const formData = new FormData();
-
       const cover = type === 'profile' ? 'false' : 'true';
       formData.append('isCover', cover);
       formData.append('image', file);
+
       getChangeImg(formData);
     }
   };

--- a/src/user/UserEditImg.tsx
+++ b/src/user/UserEditImg.tsx
@@ -1,29 +1,64 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import useAxios from '../api/useAxios';
+import { IUser } from '../types/user';
+import axios from 'axios';
 
 const COVER_IMG_URL = 'https://ifh.cc/g/ZSypny.png';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
+const TOKEN = localStorage.getItem('token');
+const headers = {
+  Authorization: `bearer ${TOKEN}`,
+  'Content-Type': 'multipart/form-data',
+};
+interface IProps {
+  id: string;
+}
 
-const UserEditImg = () => {
-  const [profileImage, setProfileImage] = useState(PROFIE_IMG_URL);
-  const [coverImage, setCoverImage] = useState(COVER_IMG_URL);
+const UserEditImg = ({ id }: IProps) => {
+  const { data, fetchData } = useAxios<IUser>({
+    url: `${API_URL}/users/${id}`,
+    method: 'get',
+  });
+
+  const [profileImage, setProfileImage] = useState('');
+  const [coverImage, setCoverImage] = useState('');
   const profileInputRef = useRef<HTMLInputElement>(null);
   const coverInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setCoverImage(data?.coverImage ?? COVER_IMG_URL);
+    setProfileImage(data?.image ?? PROFIE_IMG_URL);
+  }, [data]);
 
   const handleChangeImg = (e: React.ChangeEvent<HTMLInputElement>, type: string) => {
     if (e.currentTarget.files !== null) {
       const file = e.currentTarget.files[0];
 
       const reader = new FileReader();
-      reader.onload = () => {
+      reader.readAsDataURL(file);
+      reader.onload = async () => {
         if (reader.readyState === 2) {
           type === 'profile'
             ? setProfileImage(reader.result as string)
             : setCoverImage(reader.result as string);
         }
       };
-      reader.readAsDataURL(file);
+
+      const formData = new FormData();
+
+      const cover = type === 'profile' ? 'false' : 'true';
+      formData.append('isCover', cover);
+      formData.append('image', file);
+      getChangeImg(formData);
     }
+  };
+
+  const getChangeImg = async (formData: FormData) => {
+    await axios.post(`${API_URL}/users/upload-photo`, formData, { headers });
+
+    fetchData();
   };
 
   return (
@@ -65,4 +100,5 @@ const CoverImg = styled.img`
 const ProfileImg = styled.img`
   border-radius: 50%;
   width: 80px;
+  height: 80px;
 `;

--- a/src/user/UserEditImg.tsx
+++ b/src/user/UserEditImg.tsx
@@ -2,22 +2,22 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
-import axios from 'axios';
 
 const COVER_IMG_URL = 'https://ifh.cc/g/ZSypny.png';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
-const TOKEN = localStorage.getItem('token');
-const headers = {
-  Authorization: `bearer ${TOKEN}`,
-  'Content-Type': 'multipart/form-data',
-};
 interface IProps {
   id: string | undefined;
+  setimgFiles: React.Dispatch<React.SetStateAction<object>>;
 }
 
-const UserEditImg = ({ id }: IProps) => {
-  const { data, fetchData } = useAxios<IUser>({
+interface IImage {
+  cover?: FormData | string;
+  profile?: FormData | string;
+}
+
+const UserEditImg = ({ id, setimgFiles }: IProps) => {
+  const { data } = useAxios<IUser>({
     url: `${API_URL}/users/${id}`,
     method: 'get',
   });
@@ -26,6 +26,10 @@ const UserEditImg = ({ id }: IProps) => {
   const [coverImage, setCoverImage] = useState('');
   const profileInputRef = useRef<HTMLInputElement>(null);
   const coverInputRef = useRef<HTMLInputElement>(null);
+  const imgFileRef = useRef<IImage>({
+    cover: '',
+    profile: '',
+  });
 
   useEffect(() => {
     setCoverImage(data?.coverImage ?? COVER_IMG_URL);
@@ -51,14 +55,10 @@ const UserEditImg = ({ id }: IProps) => {
       formData.append('isCover', cover);
       formData.append('image', file);
 
-      getChangeImg(formData);
+      imgFileRef.current[type as keyof IImage] = formData;
+
+      setimgFiles(imgFileRef.current);
     }
-  };
-
-  const getChangeImg = async (formData: FormData) => {
-    await axios.post(`${API_URL}/users/upload-photo`, formData, { headers });
-
-    fetchData();
   };
 
   return (

--- a/src/user/index.tsx
+++ b/src/user/index.tsx
@@ -25,7 +25,7 @@ const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 
 const User = () => {
   const { id } = useParams();
-  const { data } = useAxios<IUser>({
+  const { data, fetchData } = useAxios<IUser>({
     url: `${API_URL}/users/${id}`,
     method: 'get',
   });
@@ -45,6 +45,10 @@ const User = () => {
       coverImage: data?.coverImage ?? COVER_IMG_URL,
     });
   }, [data]);
+
+  useEffect(() => {
+    fetchData();
+  }, []);
 
   const handlemoveEditPage = () => {
     navigate(`/userEdit/${id}`);


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가

<br/>

## 📑 작업리스트

> 작업한 목록

- 프로필 이미지 수정 기능
- 커버 이미지 수정 기능
-> 프로필 이미지 부분, 커버 이미지 부분을 클릭하면 이미지 수정이 가능합니다.
close #34 
<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항

- UserEditImg에서 input의 경우 react-hook-form으로 동적으로 서버에 저장된 url를 가져와서  defaultValue로 설정하면 이미지가 뜨지 않아서 useAxios와 useState를 이용해서 기본값을 설정했습니다. 

- 저장버튼을 눌렀을 때 이미지가 저장되도록 하고 싶어서 UserEditImg 파일에서는 객체로 cover, profile 값을 저장하고 그 값을 UseEidt로 넘겨줘서 저장버튼을 누른 경우 객체에 조건을 충족하는 값이 있으면 api를 호출하도록 설정했습니다. 혹시 더 좋은 방법 있으면 알려주세요!!

- UserEdilt에서 useMutataion을 사용하려고 했는데 로컬에 있는 게 버그 수정되기 전 버전이라 일단 pr 후 다른 파일과 함께 useMutation으로 수정할 예정입니다!

- 이미지 api 호출이 이미지 파일 크기 때문인지 속도가 느리더라구요. 나중에 최적화가 가능하다면 진행되어도 좋을 것 같습니다.

