### PR TITLE
Feature/user infofollow: 팔로잉, 팔로우 목록 확인 기능

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -6,6 +6,8 @@ import UpdatePost from './post/UpdatePost';
 import CreatePost from './post/CreatePost';
 import DetailPost from './post/DetailPost';
 import UserEdit from './user/UserEdit';
+import UserFollowers from './user/UserFollowers';
+import UserFollowing from './user/UserFollowing';
 
 function Router() {
   return (
@@ -14,6 +16,8 @@ function Router() {
         <Routes>
           <Route path='/' element={<Post />} />
           <Route path='/user/:id' element={<User />} />
+          <Route path='/followers' element={<UserFollowers />} />
+          <Route path='/following' element={<UserFollowing />} />
           <Route path='/post/:postId' element={<DetailPost />} />
           <Route path='/post/channelId/updatePost/:postId' element={<UpdatePost />} />
           <Route path='/post/create/:chnnalId' element={<CreatePost />} />

--- a/src/user/Pagination.tsx
+++ b/src/user/Pagination.tsx
@@ -27,7 +27,7 @@ const Pagination = ({ total = 0, limit, page, setPage }: IProps) => {
           } else if (page > totalPages - 3) {
             return i >= totalPages - 5;
           }
-          return i >= page - 2 && i <= page + 2;
+          return i >= page - 3 && i <= page + 1;
         })
         .map((i) => (
           <Button key={i + 1} onClick={() => setPage(i + 1)} page={page} i={i}>

--- a/src/user/UserFollowers.tsx
+++ b/src/user/UserFollowers.tsx
@@ -1,13 +1,14 @@
+import { useLocation } from 'react-router-dom';
 import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
 
-interface IProps {
-  followers: string[];
-}
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
 
-const UserFollowers = ({ followers }: IProps) => {
+const UserFollowers = () => {
+  const { state } = useLocation();
+  const followers = state.followers;
+
   const { data } = useAxios<[]>({
     url: `${API_URL}/users/get-users`,
     method: 'get',
@@ -17,12 +18,13 @@ const UserFollowers = ({ followers }: IProps) => {
 
   return (
     <>
+      <div>팔로워</div>
       {followersList &&
         followersList.map((user: IUser) => (
-          <>
+          <div key={user._id}>
             <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
             <span>{user.fullName}</span>
-          </>
+          </div>
         ))}
     </>
   );

--- a/src/user/UserFollowers.tsx
+++ b/src/user/UserFollowers.tsx
@@ -1,0 +1,31 @@
+import useAxios from '../api/useAxios';
+import { IUser } from '../types/user';
+
+interface IProps {
+  followers: string[];
+}
+const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
+const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+
+const UserFollowers = ({ followers }: IProps) => {
+  const { data } = useAxios<[]>({
+    url: `${API_URL}/users/get-users`,
+    method: 'get',
+  });
+
+  const followersList = data?.filter((user: IUser) => followers.includes(user._id));
+
+  return (
+    <>
+      {followersList &&
+        followersList.map((user: IUser) => (
+          <>
+            <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
+            <span>{user.fullName}</span>
+          </>
+        ))}
+    </>
+  );
+};
+
+export default UserFollowers;

--- a/src/user/UserFollowers.tsx
+++ b/src/user/UserFollowers.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
+import Pagination from './Pagination';
 
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
@@ -8,6 +10,9 @@ const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-pro
 const UserFollowers = () => {
   const { state } = useLocation();
   const followers = state.followers;
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const offset = (page - 1) * limit;
 
   const { data } = useAxios<[]>({
     url: `${API_URL}/users/get-users`,
@@ -20,12 +25,17 @@ const UserFollowers = () => {
     <>
       <div>팔로워</div>
       {followersList &&
-        followersList.map((user: IUser) => (
+        followersList.slice(offset, offset + limit).map((user: IUser) => (
           <div key={user._id}>
             <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
             <span>{user.fullName}</span>
           </div>
         ))}
+      {followersList && followersList.length < 1 ? (
+        <p>팔로워가 없습니다.</p>
+      ) : (
+        <Pagination total={followersList?.length as number} limit={limit} page={page} setPage={setPage} />
+      )}
     </>
   );
 };

--- a/src/user/UserFollowers.tsx
+++ b/src/user/UserFollowers.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
 import Pagination from './Pagination';
@@ -8,6 +8,7 @@ const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
 
 const UserFollowers = () => {
+  const navigate = useNavigate();
   const { state } = useLocation();
   const followers = state.followers;
   const [page, setPage] = useState(1);
@@ -20,13 +21,16 @@ const UserFollowers = () => {
   });
 
   const followersList = data?.filter((user: IUser) => followers.includes(user._id));
-
+  console.log(followersList);
+  const handleClickUser = (id: string) => {
+    navigate(`/user/${id}`);
+  };
   return (
     <>
       <div>팔로워</div>
       {followersList &&
         followersList.slice(offset, offset + limit).map((user: IUser) => (
-          <div key={user._id}>
+          <div key={user._id} onClick={() => handleClickUser(user._id)}>
             <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
             <span>{user.fullName}</span>
           </div>

--- a/src/user/UserFollowers.tsx
+++ b/src/user/UserFollowers.tsx
@@ -21,7 +21,6 @@ const UserFollowers = () => {
   });
 
   const followersList = data?.filter((user: IUser) => followers.includes(user._id));
-  console.log(followersList);
   const handleClickUser = (id: string) => {
     navigate(`/user/${id}`);
   };

--- a/src/user/UserFollowing.tsx
+++ b/src/user/UserFollowing.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
+import Pagination from './Pagination';
 
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
@@ -8,6 +10,9 @@ const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-pro
 const UserFollowing = () => {
   const { state } = useLocation();
   const following = state.following;
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const offset = (page - 1) * limit;
 
   const { data } = useAxios<[]>({
     url: `${API_URL}/users/get-users`,
@@ -20,12 +25,17 @@ const UserFollowing = () => {
     <>
       <div>팔로잉</div>
       {followingsList &&
-        followingsList.map((user: IUser) => (
+        followingsList.slice(offset, offset + limit).map((user: IUser) => (
           <div key={user._id}>
             <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
             <span>{user.fullName}</span>
           </div>
         ))}
+      {followingsList && followingsList.length < 1 ? (
+        <p>팔로잉한 계정이 없습니다.</p>
+      ) : (
+        <Pagination total={followingsList?.length as number} limit={limit} page={page} setPage={setPage} />
+      )}
     </>
   );
 };

--- a/src/user/UserFollowing.tsx
+++ b/src/user/UserFollowing.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
 import Pagination from './Pagination';
@@ -8,6 +8,7 @@ const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
 
 const UserFollowing = () => {
+  const navigate = useNavigate();
   const { state } = useLocation();
   const following = state.following;
   const [page, setPage] = useState(1);
@@ -20,13 +21,16 @@ const UserFollowing = () => {
   });
 
   const followingsList = data?.filter((user: IUser) => following.includes(user._id));
+  const handleClickUser = (id: string) => {
+    navigate(`/user/${id}`);
+  };
 
   return (
     <>
       <div>팔로잉</div>
       {followingsList &&
         followingsList.slice(offset, offset + limit).map((user: IUser) => (
-          <div key={user._id}>
+          <div key={user._id} onClick={() => handleClickUser(user._id)}>
             <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
             <span>{user.fullName}</span>
           </div>

--- a/src/user/UserFollowing.tsx
+++ b/src/user/UserFollowing.tsx
@@ -1,13 +1,14 @@
+import { useLocation } from 'react-router-dom';
 import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
 
-interface IProps {
-  following: string[];
-}
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
 
-const UserFollowing = ({ following }: IProps) => {
+const UserFollowing = () => {
+  const { state } = useLocation();
+  const following = state.following;
+
   const { data } = useAxios<[]>({
     url: `${API_URL}/users/get-users`,
     method: 'get',
@@ -17,12 +18,13 @@ const UserFollowing = ({ following }: IProps) => {
 
   return (
     <>
+      <div>팔로잉</div>
       {followingsList &&
         followingsList.map((user: IUser) => (
-          <>
+          <div key={user._id}>
             <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
             <span>{user.fullName}</span>
-          </>
+          </div>
         ))}
     </>
   );

--- a/src/user/UserFollowing.tsx
+++ b/src/user/UserFollowing.tsx
@@ -1,0 +1,31 @@
+import useAxios from '../api/useAxios';
+import { IUser } from '../types/user';
+
+interface IProps {
+  following: string[];
+}
+const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
+const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+
+const UserFollowing = ({ following }: IProps) => {
+  const { data } = useAxios<[]>({
+    url: `${API_URL}/users/get-users`,
+    method: 'get',
+  });
+
+  const followingsList = data?.filter((user: IUser) => following.includes(user._id));
+
+  return (
+    <>
+      {followingsList &&
+        followingsList.map((user: IUser) => (
+          <>
+            <img src={user.image && PROFIE_IMG_URL} width='80px' height='80px' />
+            <span>{user.fullName}</span>
+          </>
+        ))}
+    </>
+  );
+};
+
+export default UserFollowing;

--- a/src/user/UserPostListItem.tsx
+++ b/src/user/UserPostListItem.tsx
@@ -1,12 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { IPost } from '../types/post';
 
 interface IProps {
-  post: {
-    title: string;
-    likes: [];
-    _id: string;
-  };
+  post: Pick<IPost, 'title' | '_id' | 'likes'>;
 }
 const LIKE_IMG_URL = 'https://ifh.cc/g/vmscWK.png';
 

--- a/src/user/UserPostListItem.tsx
+++ b/src/user/UserPostListItem.tsx
@@ -11,7 +11,7 @@ const UserPostListItem = ({ post }: IProps) => {
   const navigate = useNavigate();
 
   const handleClickPost = (id: string) => {
-    navigate(`/posts/${id}`);
+    navigate(`/post/${id}`);
   };
 
   return (

--- a/src/user/UserPosts.tsx
+++ b/src/user/UserPosts.tsx
@@ -19,7 +19,7 @@ const UserPosts = ({ posts }: IProps) => {
         posts
           .slice(offset, offset + limit)
           .map((post: IPost) => <UserPostListItem key={post._id} post={post} />)}
-      <Pagination total={posts && posts.length} limit={limit} page={page} setPage={setPage} />
+      <Pagination total={posts?.length as number} limit={limit} page={page} setPage={setPage} />
     </>
   );
 };

--- a/src/user/UserPosts.tsx
+++ b/src/user/UserPosts.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { IPost } from '../types/post';
+import Pagination from './Pagination';
+import UserPostListItem from './UserPostListItem';
+
+interface IProps {
+  posts: [];
+}
+
+const UserPosts = ({ posts }: IProps) => {
+  const [page, setPage] = useState(1);
+
+  const limit = 7;
+  const offset = (page - 1) * limit;
+
+  return (
+    <>
+      {posts &&
+        posts
+          .slice(offset, offset + limit)
+          .map((post: IPost) => <UserPostListItem key={post._id} post={post} />)}
+      <Pagination total={posts && posts.length} limit={limit} page={page} setPage={setPage} />
+    </>
+  );
+};
+
+export default UserPosts;

--- a/src/user/index.tsx
+++ b/src/user/index.tsx
@@ -3,20 +3,16 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { IUser } from '../types/user';
 import styled from 'styled-components';
 import useAxios from '../api/useAxios';
-import Pagination from './Pagination';
-import UserPostListItem from './UserPostListItem';
+import UserPosts from './UserPosts';
+import { IPost } from '../types/post';
 
 interface IUserInfo {
   fullName: string | undefined;
   posts: [];
   image: string;
   coverImage: string;
-}
-
-interface IPost {
-  _id: string;
-  title: string;
-  likes: [];
+  followers: number;
+  following: number;
 }
 
 const COVER_IMG_URL = 'https://ifh.cc/g/xBfBwB.png';
@@ -35,11 +31,10 @@ const User = () => {
     posts: [],
     image: '',
     coverImage: '',
+    followers: 0,
+    following: 0,
   });
-  const [page, setPage] = useState(1);
   const navigate = useNavigate();
-  const limit = 7;
-  const offset = (page - 1) * limit;
 
   useEffect(() => {
     setUserInfo({
@@ -47,6 +42,8 @@ const User = () => {
       posts: data?.posts as [],
       image: data?.image ?? PROFIE_IMG_URL,
       coverImage: data?.coverImage ?? COVER_IMG_URL,
+      followers: data?.followers.length as number,
+      following: data?.following.length as number,
     });
   }, [data]);
 
@@ -68,17 +65,11 @@ const User = () => {
         <img src={LIKE_IMG_URL} />
         {totalLikes}
       </div>
+      <div>
+        팔로워 {userInfo.followers} 팔로잉 {userInfo.following}
+      </div>
       <button onClick={handlemoveEditPage}>내 정보 수정</button>
-      {userInfo.posts &&
-        userInfo.posts
-          .slice(offset, offset + limit)
-          .map((post: IPost) => <UserPostListItem key={post._id} post={post} />)}
-      <Pagination
-        total={userInfo.posts && userInfo.posts.length}
-        limit={limit}
-        page={page}
-        setPage={setPage}
-      />
+      {userInfo.posts && userInfo.posts.length > 0 && <UserPosts posts={userInfo.posts} />}
     </>
   );
 };

--- a/src/user/index.tsx
+++ b/src/user/index.tsx
@@ -5,14 +5,15 @@ import styled from 'styled-components';
 import useAxios from '../api/useAxios';
 import UserPosts from './UserPosts';
 import { IPost } from '../types/post';
+import { IFollow } from '../types/follow';
+import UserFollowing from './UserFollowing';
+import UserFollowers from './UserFollowers';
 
 interface IUserInfo {
   fullName: string | undefined;
   posts: [];
   image: string;
   coverImage: string;
-  followers: number;
-  following: number;
 }
 
 const COVER_IMG_URL = 'https://ifh.cc/g/xBfBwB.png';
@@ -22,6 +23,7 @@ const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 
 const User = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
   const { data, fetchData } = useAxios<IUser>({
     url: `${API_URL}/users/${id}`,
     method: 'get',
@@ -31,10 +33,11 @@ const User = () => {
     posts: [],
     image: '',
     coverImage: '',
-    followers: 0,
-    following: 0,
   });
-  const navigate = useNavigate();
+  const [userFollow, setUserFollow] = useState({
+    followers: [],
+    following: [],
+  });
 
   useEffect(() => {
     setUserInfo({
@@ -42,8 +45,13 @@ const User = () => {
       posts: data?.posts as [],
       image: data?.image ?? PROFIE_IMG_URL,
       coverImage: data?.coverImage ?? COVER_IMG_URL,
-      followers: data?.followers.length as number,
-      following: data?.following.length as number,
+    });
+    const followerList = data?.followers.map((user: IFollow) => user.user);
+    const followingList = data?.following.map((user: IFollow) => user.user);
+
+    setUserFollow({
+      followers: followerList as [],
+      following: followingList as [],
     });
   }, [data]);
 
@@ -65,9 +73,8 @@ const User = () => {
         <img src={LIKE_IMG_URL} />
         {totalLikes}
       </div>
-      <div>
-        팔로워 {userInfo.followers} 팔로잉 {userInfo.following}
-      </div>
+      <UserFollowers followers={userFollow.followers} />
+      <UserFollowing following={userFollow.following} />
       <button onClick={handlemoveEditPage}>내 정보 수정</button>
       {userInfo.posts && userInfo.posts.length > 0 && <UserPosts posts={userInfo.posts} />}
     </>

--- a/src/user/index.tsx
+++ b/src/user/index.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { IUser } from '../types/user';
 import styled from 'styled-components';
 import useAxios from '../api/useAxios';
-import UserPosts from './UserPosts';
 import { IPost } from '../types/post';
 import { IFollow } from '../types/follow';
-import UserFollowing from './UserFollowing';
-import UserFollowers from './UserFollowers';
+import UserPosts from './UserPosts';
 
 interface IUserInfo {
   fullName: string | undefined;
@@ -73,9 +71,14 @@ const User = () => {
         <img src={LIKE_IMG_URL} />
         {totalLikes}
       </div>
-      <UserFollowers followers={userFollow.followers} />
-      <UserFollowing following={userFollow.following} />
       <button onClick={handlemoveEditPage}>내 정보 수정</button>
+
+      <Link to={`/followers`} state={{ followers: userFollow.followers }}>
+        팔로워: {userFollow.followers && userFollow.followers.length}
+      </Link>
+      <Link to={`/following`} state={{ following: userFollow.following }}>
+        팔로잉: {userFollow.following && userFollow.following.length}
+      </Link>
       {userInfo.posts && userInfo.posts.length > 0 && <UserPosts posts={userInfo.posts} />}
     </>
   );


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가

<br/>

## 📑 작업리스트

> 작업한 목록

- 팔로워, 팔로잉 수 보여주기
- 팔로워, 팔로잉 클릭 시 해당 목록 보여주기
- 팔로워, 팔로잉 목록에서 유저 클릭 시 해당 유저 정보 페이지로 이동
- 글 목록 클릭 시 해당 글의 상세 페이지로 이동
close #52 
<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항
- 현재 팔로워, 팔로잉을 누르면 아예 페이지가 변경되는데 페이지 접근 상 커버이미지, 프로필 이미지 등의 상단 정보는 유지한 채로 글 목록 부분에서 팔로잉, 팔로워 목록을 띄우는 게 좋을까요? 해당 방법으로 구현하긴했었는데 그러면 posts에 대해 api 호출이 추가되어서 일단 현재 방법으로 구현해두었습니다. 
- 라우터 주소를 수정해서 내 정보 페이지에서 글 목록을 누르면 해당 글의 상세 페이지로 이동됩니다. 특정 유저 글 목록 페이지 변경 시 에러가 있는 것은 title에 들어간 데이터 형식이 달라서 그런 것이니 무시하셔도 됩니당. 