### PR TITLE
Feature/search: 특정 채널 포스트 리스트 라우터 연결 및 메인 페이지 검색 기능 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,7 +5,7 @@ import User from './user';
 import UpdatePost from './post/UpdatePost';
 import CreatePost from './post/CreatePost';
 import DetailPost from './post/DetailPost';
-import Search from './search';
+import Search from './search/Index';
 // import UserEdit from './user/UserEdit';
 
 function Router() {

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,7 +5,7 @@ import User from './user';
 import UpdatePost from './post/UpdatePost';
 import CreatePost from './post/CreatePost';
 import DetailPost from './post/DetailPost';
-
+import Search from './search';
 // import UserEdit from './user/UserEdit';
 
 function Router() {
@@ -18,6 +18,7 @@ function Router() {
           <Route path='/post/:postId' element={<DetailPost />} />
           <Route path='/post/channelId/updatePost/:postId' element={<UpdatePost />} />
           <Route path='/post/create/:chnnalId' element={<CreatePost />} />
+          <Route path='/channel/:channelId' element={<Search />} />
           {/* <Route path='/userEdit/:id' element={<UserEdit />} /> */}
         </Routes>
       </Layout>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -14,7 +14,6 @@ function Router() {
       <Layout>
         <Routes>
           <Route path='/' element={<Post />} />
-          <Route path='/' element={<Search />} />
           <Route path='/user/:id' element={<User />} />
           <Route path='/post/:postId' element={<DetailPost />} />
           <Route path='/post/channelId/updatePost/:postId' element={<UpdatePost />} />

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -14,6 +14,7 @@ function Router() {
       <Layout>
         <Routes>
           <Route path='/' element={<Post />} />
+          <Route path='/' element={<Search />} />
           <Route path='/user/:id' element={<User />} />
           <Route path='/post/:postId' element={<DetailPost />} />
           <Route path='/post/channelId/updatePost/:postId' element={<UpdatePost />} />

--- a/src/layout/Channels.tsx
+++ b/src/layout/Channels.tsx
@@ -5,15 +5,12 @@ import styled from 'styled-components';
 
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 
-interface ISetSelectedChannelId {
-  setSelectedChannelId: (value: string) => void;
-}
 interface Channel {
   _id: string;
   name: string;
 }
 
-const Channels = ({ setSelectedChannelId }: ISetSelectedChannelId) => {
+const Channels = () => {
   const [channelList, setChannelList] = useState([]);
   const navigate = useNavigate();
   useEffect(() => {
@@ -25,7 +22,6 @@ const Channels = ({ setSelectedChannelId }: ISetSelectedChannelId) => {
   };
 
   const handleClickMoveChannel = (id: string) => {
-    setSelectedChannelId(id);
     navigate(`/channel/${id}`);
   };
 

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -2,22 +2,17 @@ import React from 'react';
 import Channels from './Channels';
 import Header from './Header';
 import styled from 'styled-components';
-import Search from '../search/Index';
-import { useState } from 'react';
+
 interface Props {
   children: React.ReactNode;
 }
 
 const Layout = ({ children }: Props) => {
-  const [selectedChannelId, setSelectedChannelId] = useState('');
   return (
     <>
       <Header />
-      <Channels setSelectedChannelId={setSelectedChannelId} />
-      <Main>
-        {children}
-        <Search channelId={selectedChannelId} />
-      </Main>
+      <Channels />
+      <Main>{children}</Main>
     </>
   );
 };

--- a/src/post/index.tsx
+++ b/src/post/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import ErrorBoundary from '../api/ErrorBoundary';
-import Search from '../search';
+import Search from '../search/Index';
 function Post() {
   const navigate = useNavigate();
   const tempOnClickPostRead = () => {

--- a/src/post/index.tsx
+++ b/src/post/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import ErrorBoundary from '../api/ErrorBoundary';
-
+import Search from '../search';
 function Post() {
   const navigate = useNavigate();
   const tempOnClickPostRead = () => {
@@ -13,6 +13,7 @@ function Post() {
   return (
     <>
       <ErrorBoundary>
+        <Search />
         <h1>언성히어로 최고🤗</h1>
         <button onClick={tempOnClickPostRead}>임시 글 읽기 버튼</button>
         <button onClick={tempOnClickPostCreate}>임시 글 쓰기 버튼</button>

--- a/src/search/Index.tsx
+++ b/src/search/Index.tsx
@@ -3,13 +3,12 @@ import PostListContainer from './PostListContainer';
 import { useState, useEffect } from 'react';
 import ErrorBoundary from '../api/ErrorBoundary';
 import axios from 'axios';
-import { useLocation, useParams } from 'react-router-dom';
-import { idText } from 'typescript';
+import { useParams } from 'react-router-dom';
 
 const API_END_POINT = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 
 const Search = () => {
-  const [postsInfo, setPostsInfo] = useState([]); //PostListContainer에 넘겨 줄 데이터들
+  const [postsInfo, setPostsInfo] = useState([]);
   const [selectedSearchOption, setSelectedSearchOption] = useState('');
   const [inputSearchValue, setInputSearchValue] = useState('');
   const [presentChannelId, setPresentChannelId] = useState<string | undefined>('');
@@ -44,6 +43,7 @@ const Search = () => {
         postsInfo={postsInfo}
         selectedSearchOption={selectedSearchOption}
         inputSearchValue={inputSearchValue}
+        presentChannelId={presentChannelId}
       />
     </ErrorBoundary>
   );

--- a/src/search/Index.tsx
+++ b/src/search/Index.tsx
@@ -3,30 +3,30 @@ import PostListContainer from './PostListContainer';
 import { useState, useEffect } from 'react';
 import ErrorBoundary from '../api/ErrorBoundary';
 import axios from 'axios';
+import { useLocation, useParams } from 'react-router-dom';
+import { idText } from 'typescript';
 
 const API_END_POINT = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 
-interface IsearchProps {
-  channelId: string | '';
-}
-
-const Search = ({ channelId }: IsearchProps) => {
+const Search = () => {
   const [postsInfo, setPostsInfo] = useState([]); //PostListContainer에 넘겨 줄 데이터들
   const [selectedSearchOption, setSelectedSearchOption] = useState('');
   const [inputSearchValue, setInputSearchValue] = useState('');
+  const [presentChannelId, setPresentChannelId] = useState<string | undefined>('');
+  const { channelId } = useParams();
+
+  if (presentChannelId !== channelId) {
+    setPresentChannelId(channelId);
+  }
 
   useEffect(() => {
-    if (channelId === '') {
-      console.log('channelId가 없는 경우 어떤 처리를 해주면 좋을지 고민중...');
-    } else {
-      getPostsList();
-      setSelectedSearchOption('');
-      setInputSearchValue('');
-    }
-  }, [channelId]);
+    getPostsList();
+    setSelectedSearchOption('');
+    setInputSearchValue('');
+  }, [presentChannelId]);
 
   const getPostsList = async () => {
-    axios.get(`${API_END_POINT}/posts/channel/${channelId}`).then((response) => {
+    axios.get(`${API_END_POINT}/posts/channel/${presentChannelId}`).then((response) => {
       const { data } = response;
       setPostsInfo(data);
     });
@@ -38,7 +38,7 @@ const Search = ({ channelId }: IsearchProps) => {
         setSelectedSearchOption={setSelectedSearchOption}
         setInputSearchValue={setInputSearchValue}
         getPostsList={getPostsList}
-        channelId={channelId}
+        channelId={presentChannelId}
       />
       <PostListContainer
         postsInfo={postsInfo}

--- a/src/search/Index.tsx
+++ b/src/search/Index.tsx
@@ -11,21 +11,30 @@ const Search = () => {
   const [postsInfo, setPostsInfo] = useState([]);
   const [selectedSearchOption, setSelectedSearchOption] = useState('');
   const [inputSearchValue, setInputSearchValue] = useState('');
-  const [presentChannelId, setPresentChannelId] = useState<string | undefined>('');
+  const [currentChannelId, setCurrentChannelId] = useState<string | undefined>('');
   const { channelId } = useParams();
 
-  if (presentChannelId !== channelId) {
-    setPresentChannelId(channelId);
+  if (channelId !== currentChannelId) {
+    setCurrentChannelId(channelId);
   }
 
   useEffect(() => {
-    getPostsList();
-    setSelectedSearchOption('');
-    setInputSearchValue('');
-  }, [presentChannelId]);
+    if (currentChannelId !== undefined) {
+      getPostsList();
+      setSelectedSearchOption('');
+      setInputSearchValue('');
+    }
+  }, [currentChannelId]);
 
   const getPostsList = async () => {
-    axios.get(`${API_END_POINT}/posts/channel/${presentChannelId}`).then((response) => {
+    axios.get(`${API_END_POINT}/posts/channel/${currentChannelId}`).then((response) => {
+      const { data } = response;
+      setPostsInfo(data);
+    });
+  };
+
+  const getEntirePostsList = async () => {
+    axios.get(`${API_END_POINT}/posts`).then((response) => {
       const { data } = response;
       setPostsInfo(data);
     });
@@ -37,13 +46,14 @@ const Search = () => {
         setSelectedSearchOption={setSelectedSearchOption}
         setInputSearchValue={setInputSearchValue}
         getPostsList={getPostsList}
-        channelId={presentChannelId}
+        getEntirePostsList={getEntirePostsList}
+        channelId={currentChannelId}
       />
       <PostListContainer
         postsInfo={postsInfo}
         selectedSearchOption={selectedSearchOption}
         inputSearchValue={inputSearchValue}
-        presentChannelId={presentChannelId}
+        presentChannelId={currentChannelId}
       />
     </ErrorBoundary>
   );

--- a/src/search/Index.tsx
+++ b/src/search/Index.tsx
@@ -47,7 +47,7 @@ const Search = () => {
         setInputSearchValue={setInputSearchValue}
         getPostsList={getPostsList}
         getEntirePostsList={getEntirePostsList}
-        channelId={currentChannelId}
+        currentChannelId={currentChannelId}
       />
       <PostListContainer
         postsInfo={postsInfo}

--- a/src/search/Pagination.tsx
+++ b/src/search/Pagination.tsx
@@ -6,6 +6,7 @@ interface IpaginationProps {
   page: number;
   totalPosts: number;
   setPage: (value: number) => void;
+  presentChannelId: string | undefined;
 }
 
 interface IButtonStyle {
@@ -13,12 +14,12 @@ interface IButtonStyle {
   i: number;
 }
 
-const Pagination = ({ totalPosts, limit, page, setPage }: IpaginationProps) => {
+const Pagination = ({ totalPosts, limit, page, setPage, presentChannelId }: IpaginationProps) => {
   const totalPages = Math.ceil(totalPosts / limit);
 
   useEffect(() => {
     setPage(1);
-  }, [totalPosts]);
+  }, [presentChannelId]);
 
   return (
     <>

--- a/src/search/Pagination.tsx
+++ b/src/search/Pagination.tsx
@@ -34,7 +34,7 @@ const Pagination = ({ totalPosts, limit, page, setPage, presentChannelId }: Ipag
           } else if (page > totalPages - 3) {
             return i >= totalPages - 5;
           }
-          return i >= page - 2 && i <= page + 2;
+          return i >= page - 3 && i <= page + 1;
         })
         .map((i) => (
           <Button key={i + 1} onClick={() => setPage(i + 1)} page={page} i={i}>

--- a/src/search/PostList.tsx
+++ b/src/search/PostList.tsx
@@ -57,7 +57,7 @@ const PostList = ({ filteredPostsInfo, selectedSearchOption, inputSearchValue }:
           const postContent = IsJsonString(title) ? JSON.parse(title).content : ' ';
 
           return (
-            <li key={_id} onClick={() => navigatePost(`/post/:${_id}`)}>
+            <li key={_id} onClick={() => navigatePost(`/post/${_id}`)}>
               <div>
                 <div>
                   제목:{' '}

--- a/src/search/PostListContainer.tsx
+++ b/src/search/PostListContainer.tsx
@@ -18,6 +18,7 @@ interface IpostsInfo {
   likes: Ilikes[];
   createdAt: string;
 }
+
 interface IpostListContainerProps {
   postsInfo: IpostsInfo[];
   selectedSearchOption: string;

--- a/src/search/PostListContainer.tsx
+++ b/src/search/PostListContainer.tsx
@@ -22,12 +22,14 @@ interface IpostListContainerProps {
   postsInfo: IpostsInfo[];
   selectedSearchOption: string;
   inputSearchValue: string;
+  presentChannelId: string | undefined;
 }
 
 const PostListContainer = ({
   postsInfo,
   selectedSearchOption,
   inputSearchValue,
+  presentChannelId,
 }: IpostListContainerProps) => {
   const [page, setPage] = useState(1);
   const [checkedSorting, setCheckedSorting] = useState(true);
@@ -36,7 +38,7 @@ const PostListContainer = ({
 
   useEffect(() => {
     setCheckedSorting(true);
-  }, [postsInfo]);
+  }, [presentChannelId]);
 
   const dividePosts = (posts: any) => {
     const result = posts.slice(offset, offset + limit);
@@ -99,7 +101,13 @@ const PostListContainer = ({
         selectedSearchOption={selectedSearchOption}
         inputSearchValue={inputSearchValue}
       />
-      <Pagination limit={limit} page={page} totalPosts={filterPosts().length} setPage={setPage} />
+      <Pagination
+        limit={limit}
+        page={page}
+        totalPosts={filterPosts().length}
+        setPage={setPage}
+        presentChannelId={presentChannelId}
+      />
     </>
   );
 };

--- a/src/search/SearchBox.tsx
+++ b/src/search/SearchBox.tsx
@@ -4,7 +4,7 @@ interface IsearchBoxProps {
   setSelectedSearchOption: (value: string) => void;
   setInputSearchValue: (value: string) => void;
   getPostsList: () => void;
-  channelId: string;
+  channelId: string | undefined;
 }
 
 const SearchBox = ({

--- a/src/search/SearchBox.tsx
+++ b/src/search/SearchBox.tsx
@@ -5,7 +5,7 @@ interface IsearchBoxProps {
   setInputSearchValue: (value: string) => void;
   getPostsList: () => void;
   getEntirePostsList: () => void;
-  channelId: string | undefined;
+  currentChannelId: string | undefined;
 }
 
 const SearchBox = ({
@@ -13,7 +13,7 @@ const SearchBox = ({
   setInputSearchValue,
   getPostsList,
   getEntirePostsList,
-  channelId,
+  currentChannelId,
 }: IsearchBoxProps) => {
   const [inputValue, setInputValue] = useState('');
   const [selectedOption, setSelectedOption] = useState('제목');
@@ -22,7 +22,7 @@ const SearchBox = ({
   useEffect(() => {
     setInputValue('');
     setSelectedOption('제목');
-  }, [channelId]);
+  }, [currentChannelId]);
 
   const handleChangeInput = useCallback((e: React.ChangeEvent<HTMLInputElement>): void => {
     setInputValue(e.target.value);
@@ -37,13 +37,13 @@ const SearchBox = ({
       e.preventDefault();
       setSelectedSearchOption(selectedOption);
       setInputSearchValue(inputValue);
-      if (channelId !== undefined) {
+      if (currentChannelId !== undefined) {
         getPostsList();
-      } else if (channelId === undefined) {
+      } else if (currentChannelId === undefined) {
         getEntirePostsList();
       }
     },
-    [inputValue, selectedOption, channelId]
+    [inputValue, selectedOption, currentChannelId]
   );
 
   return (

--- a/src/search/SearchBox.tsx
+++ b/src/search/SearchBox.tsx
@@ -4,6 +4,7 @@ interface IsearchBoxProps {
   setSelectedSearchOption: (value: string) => void;
   setInputSearchValue: (value: string) => void;
   getPostsList: () => void;
+  getEntirePostsList: () => void;
   channelId: string | undefined;
 }
 
@@ -11,6 +12,7 @@ const SearchBox = ({
   setSelectedSearchOption,
   setInputSearchValue,
   getPostsList,
+  getEntirePostsList,
   channelId,
 }: IsearchBoxProps) => {
   const [inputValue, setInputValue] = useState('');
@@ -35,9 +37,13 @@ const SearchBox = ({
       e.preventDefault();
       setSelectedSearchOption(selectedOption);
       setInputSearchValue(inputValue);
-      getPostsList();
+      if (channelId !== undefined) {
+        getPostsList();
+      } else if (channelId === undefined) {
+        getEntirePostsList();
+      }
     },
-    [inputValue, selectedOption]
+    [inputValue, selectedOption, channelId]
   );
 
   return (


### PR DESCRIPTION
## 📘 작업 유형

- 리팩토링

<br/>

## 📑 작업리스트

> 작업한 목록

- 특정 채널 포스트 목록 불러오기에 라우터 연결
- 특정 채널 선택 없이 메인 페이지에서 검색한 경우 전체 검색 가능
 close #61 

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항
메인 페이지의 검색 기능은 현재 페이지 이동 없이 바로 메인 페이지에서 전체 검색을 통한 결과가 출력되도록 구현해 놓았는데
추후 '전체 글' 채널이 생성된 후 메인 페이지에서 검색시 '전체 글' 채널로 이동하여 검색 결과가 출력될 수 있도록 연결할 생각입니다.
