### PR TITLE
Feature/notifications: 알람 관련 추가 기능 구현

### DIFF
--- a/src/contexts/NotificationStatusProvider.tsx
+++ b/src/contexts/NotificationStatusProvider.tsx
@@ -1,0 +1,20 @@
+import React, { useState, createContext, useContext } from 'react';
+import { INotificationStatus } from '../types/notification';
+
+const notificationStatusContext = createContext<INotificationStatus | null>(null);
+
+export const useNotificationStatus = () => useContext(notificationStatusContext);
+
+const NotificationStatusProvider = ({ children }: { children: React.ReactNode }) => {
+  const [notificationStatus, setNotificationStatus] = useState(false);
+
+  const setNotification = (bool: boolean) => setNotificationStatus(bool);
+
+  return (
+    <notificationStatusContext.Provider value={{ notificationStatus, setNotification }}>
+      {children}
+    </notificationStatusContext.Provider>
+  );
+};
+
+export default NotificationStatusProvider;

--- a/src/notification/NotificationList.tsx
+++ b/src/notification/NotificationList.tsx
@@ -1,24 +1,23 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import NotificationlistItem from './NotificationListItem';
-import { INotification } from '../types/notification';
+import { INotification, INotificationStatus } from '../types/notification';
 import useMutation from '../api/useMutation';
 import { useToken } from '../contexts/TokenProvider';
 import { IToken } from '../types/token';
+import { useNotificationStatus } from '../contexts/NotificationStatusProvider';
 
 const NotificationList = () => {
   const [notificationList, setNotificationlist] = useState<INotification[]>();
-  const [notificationStatus, setNotificationStatus] = useState<boolean | undefined>(false);
   const [showedNotificationListStatus, setShowedNotificationListStatus] = useState(false);
 
   const tokenContextObj: IToken | null = useToken();
+  const notificationStatusContextObj: INotificationStatus | null = useNotificationStatus();
 
   const { mutate } = useMutation();
 
-  // by 민형, 이미 모든 알람을 열어본 경우에는 해당 로직이 수행되지 않도록(리팩토링)_230111
-  // by 민형, 리팩토링 완료_230112
   const confirmNotificationlist = () => {
-    if (notificationStatus) return;
+    if (!notificationStatusContextObj?.notificationStatus) return;
 
     mutate({
       url: `http://kdt.frontend.3rd.programmers.co.kr:5006/notifications/seen`,
@@ -45,7 +44,7 @@ const NotificationList = () => {
   const updateNotificationStatus = () => {
     const notificationListData = notificationList?.map(({ seen }) => seen);
     const notificationState = notificationListData?.includes(false);
-    setNotificationStatus(!notificationState);
+    notificationStatusContextObj?.setNotification(!!notificationState);
   };
 
   const toggleShowedNotificationListStatus = () =>

--- a/src/notification/NotificationList.tsx
+++ b/src/notification/NotificationList.tsx
@@ -5,6 +5,7 @@ import { INotification, INotificationStatus } from '../types/notification';
 import { useToken } from '../contexts/TokenProvider';
 import { IToken } from '../types/token';
 import { useNotificationStatus } from '../contexts/NotificationStatusProvider';
+import ProduceNotification from './ProduceNotification';
 
 const NotificationList = () => {
   const [notificationList, setNotificationlist] = useState<INotification[]>();
@@ -35,7 +36,7 @@ const NotificationList = () => {
         headers: { Authorization: `bearer ${tokenContextObj?.token}` },
       })
       .then((res) => {
-        if (notificationLength !== res.data.length) {
+        if (notificationLength !== res.data.length || notificationStatusContextObj?.notificationStatus) {
           setNotificationlist(res.data);
           setNotificationLength(res.data.length);
         }
@@ -65,12 +66,21 @@ const NotificationList = () => {
       <button onClick={confirmNotificationlist} style={{ width: '100vw' }}>
         모든 알림 확인
       </button>
-      <div style={{ display: 'flex', justifyContent: 'center' }}>
-        {notificationList?.map(({ _id, seen: isCheck, comment }) => (
-          <NotificationlistItem key={_id} _id={_id} seen={isCheck} comment={comment} />
+      <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
+        {notificationList?.map(({ _id, seen: isCheck, comment, like, author, post }) => (
+          <NotificationlistItem
+            key={_id}
+            _id={_id}
+            seen={isCheck}
+            comment={comment}
+            like={like}
+            author={author}
+            post={post}
+          />
         ))}
       </div>
       <button onClick={fetchNotificationData}>실시간 알람 확인</button>
+      <ProduceNotification />
     </>
   );
 };

--- a/src/notification/NotificationListItem.tsx
+++ b/src/notification/NotificationListItem.tsx
@@ -1,18 +1,28 @@
+import { useNavigate } from 'react-router-dom';
 import { INotification } from '../types/notification';
 
-const NotificationListItem = ({ _id, seen, comment }: INotification) => {
+const NotificationListItem = ({ _id, seen, comment, like, author, post: postId }: INotification) => {
+  const navigate = useNavigate();
+
   return (
     <div
+      onClick={() => navigate(`/post/${postId}`)}
       style={{
         width: '200px',
         height: '200px',
         marginRight: '20px',
+        marginBottom: '10px',
         backgroundColor: seen ? 'red' : 'yellow',
       }}
       key={_id}
     >
       {seen ? <div>----확인 한 댓글----</div> : <div>----확인 전 댓글----</div>}
-      {comment?.comment ? <div>{comment.comment}</div> : '댓글 없음'}
+      {
+        <div>
+          {author?.fullName}님이 {comment ? '댓글을 남기셨습니다' : '공감을 하셨습니다'}
+        </div>
+      }
+      {<div>글제목 : {comment ? comment?.post.title : like?.post.title}</div>}
     </div>
   );
 };

--- a/src/notification/NotificationStatus.tsx
+++ b/src/notification/NotificationStatus.tsx
@@ -26,7 +26,7 @@ const NotificationStatus = () => {
   };
 
   const checkNotificationStatus = () => {
-    if (notificationStatusList.indexOf(false) !== -1) notificationStatusContextObj?.setNotification(true);
+    if (notificationStatusList.includes(false)) notificationStatusContextObj?.setNotification(true);
   };
 
   useEffect(() => {

--- a/src/notification/NotificationStatus.tsx
+++ b/src/notification/NotificationStatus.tsx
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import { useToken } from '../contexts/TokenProvider';
+import { IToken } from '../types/token';
+import { INotification } from '../types/notification';
+import { useState, useEffect } from 'react';
+
+const NotificationStatus = () => {
+  const [notificationStatusList, setNotificationStatusList] = useState<boolean[]>([]);
+  const [notificationStatus, setNotificationStatus] = useState<boolean>();
+  const tokenContextObj: IToken | null = useToken();
+
+  const fetchNotificationData = async () => {
+    await axios
+      .get('http://kdt.frontend.3rd.programmers.co.kr:5006/notifications', {
+        headers: { Authorization: `bearer ${tokenContextObj?.token}` },
+      })
+      .then((res) => {
+        const serverData = res.data;
+        const allSeenCheckData = serverData.map((data: INotification) => data.seen);
+        setNotificationStatusList(allSeenCheckData);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  const checkNotificationStatus = () => {
+    if (notificationStatusList.indexOf(false) !== -1) setNotificationStatus(true);
+  };
+
+  useEffect(() => {
+    fetchNotificationData();
+  }, []);
+
+  useEffect(() => {
+    checkNotificationStatus();
+  }, [notificationStatusList]);
+
+  return (
+    <>
+      {notificationStatus && (
+        <div style={{ width: '30px', height: '30px', borderRadius: '50%', backgroundColor: 'green' }}></div>
+      )}
+    </>
+  );
+};
+
+export default NotificationStatus;

--- a/src/notification/NotificationStatus.tsx
+++ b/src/notification/NotificationStatus.tsx
@@ -1,13 +1,14 @@
 import axios from 'axios';
 import { useToken } from '../contexts/TokenProvider';
 import { IToken } from '../types/token';
-import { INotification } from '../types/notification';
+import { useNotificationStatus } from '../contexts/NotificationStatusProvider';
+import { INotification, INotificationStatus } from '../types/notification';
 import { useState, useEffect } from 'react';
 
 const NotificationStatus = () => {
   const [notificationStatusList, setNotificationStatusList] = useState<boolean[]>([]);
-  const [notificationStatus, setNotificationStatus] = useState<boolean>();
   const tokenContextObj: IToken | null = useToken();
+  const notificationStatusContextObj: INotificationStatus | null = useNotificationStatus();
 
   const fetchNotificationData = async () => {
     await axios
@@ -25,7 +26,7 @@ const NotificationStatus = () => {
   };
 
   const checkNotificationStatus = () => {
-    if (notificationStatusList.indexOf(false) !== -1) setNotificationStatus(true);
+    if (notificationStatusList.indexOf(false) !== -1) notificationStatusContextObj?.setNotification(true);
   };
 
   useEffect(() => {
@@ -38,7 +39,7 @@ const NotificationStatus = () => {
 
   return (
     <>
-      {notificationStatus && (
+      {notificationStatusContextObj?.notificationStatus && (
         <div style={{ width: '30px', height: '30px', borderRadius: '50%', backgroundColor: 'green' }}></div>
       )}
     </>

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -18,3 +18,7 @@ export interface INotification {
   notificationType?: string;
   notificationTypeId?: string;
 }
+export interface INotificationStatus {
+  notificationStatus: boolean;
+  setNotification: (bool: boolean) => void;
+}

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,7 +1,15 @@
 import { IUser } from './user';
 
 interface IComment {
-  comment: string;
+  post: {
+    title: string;
+  };
+}
+
+interface ILike {
+  post: {
+    title: string;
+  };
 }
 
 export interface INotification {
@@ -12,6 +20,8 @@ export interface INotification {
   postId?: string | null;
   follow?: string;
   comment?: IComment;
+  like?: ILike;
+  post?: string;
   message?: string;
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가
- 경미한 버그 수정

<br/>

## 📑 작업리스트

> 작업한 목록

-  알람 버튼 컴포넌트로 분리
- 메인 페이지에 있을 때 알람 받은 경우
- [ ] 메인 페이지에 머무를 때 알람 받은 경우 알람 페이지로 이동하면 알람 표시가 render 되도록
- [ ] 알람 페이지에서 모든 알람 목록을 확인하면 알람 표시가 제거 되도록
- 실시간 알람 check 버튼
- 알람 관련 나머지 기능
- [ ] 실시간 알람 버튼 클릭 후 모든 알람 확인 버튼 클릭하면 반영 안되는 문제 해결
- [ ] 알람에 표시 될 내용 render 및 좋아요 알람 인지 댓글 알람 인지 분리
- [ ] 특정 알람을 클릭하면 해당 포스트로 이동
- close #56

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항
- [ ] notificationStatus를 context로 관리(사용하시게되면 꼭 Provider를 설정해주셔야 합니다!)
- [ ] layout > header의에 NotificationStatus 컴포넌트를 추가하시면 알람 상태여부를 check 할 수 있습니다.
```tsx
// Header.tsx

import NotificationStatus from '../notification/NotificationStatus';

<>
    // header의 버튼을 설정하는 곳
    <NotificationStatus />
</>
```
- [ ] Router 등록도 하셔야 합니다.
```tsx
// Router.tsx
import NotificationList from './notification/NotificationList';

<Route path='/notifications' element={<NotificationList />} />
```
- [ ] 로그인 후에(혹시나해서 계정정보는 적어두지 않을테니 필요하신 분은 슬랙으로 요청주세요) 알람과 관련해서 위에 작성한 기능을 하나씩 수행하시면서 문제점을 찾아주시면 좋을 것 같습니다.