### PR TITLE
refactor/context: 로그인을 해야만 token context 사용 가능

### DIFF
--- a/src/contexts/TokenProvider.tsx
+++ b/src/contexts/TokenProvider.tsx
@@ -10,12 +10,23 @@ const TOKEN_KEY = 'token';
 
 const TokenProvider = ({ children }: { children: React.ReactNode }) => {
   const [localToken] = useLocalStorage(TOKEN_KEY, '');
+
+  const [checkTokenCertification, setCheckTokenCertification] = useState<boolean>(false);
   const [token, setToken] = useState(localToken);
 
-  const addToken = (getToken: string) => setToken(getToken);
-  const removeToken = () => setToken(null);
+  const addToken = (getToken: string) => {
+    setToken(getToken);
+    setCheckTokenCertification(true);
+  };
+  const removeToken = () => setToken('');
 
-  return <TokenContext.Provider value={{ token, addToken, removeToken }}>{children}</TokenContext.Provider>;
+  return (
+    <TokenContext.Provider
+      value={{ token: checkTokenCertification ? token : undefined, addToken, removeToken }}
+    >
+      {children}
+    </TokenContext.Provider>
+  );
 };
 
 export default TokenProvider;

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -1,5 +1,5 @@
 export interface IToken {
-  token: string | undefined;
+  token: string;
   addToken: (getToken: string) => void;
   removeToken: () => void;
 }


### PR DESCRIPTION
## 📘 작업 유형

- 버그 수정

<br/>

## 📑 작업리스트

> 작업한 목록

- 사용자가 임의의로 localStorage에 key와 value를 추가 한 다음 새로고침을 하면 로그인이 되는 문제가 있었습니다.
- 로그인 시에만 token 값을 사용할 수 있도록 하고 그 외 사항(처음 페이지 들어왔을 때, 사용자가 임의로 local에 값을 바꿀 때)에는 token을 사용할 수 없도록 구현하였습니다.

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항
- 예외사항 처리이다 보니 제가 빠뜨린 부분이 있을 것 같다고 예상이 됩니다. 혹시 그런 부분과 관련해서 리뷰 날려주시면 감사하겠습니다.