### PR TITLE
Refactor/user: userId 전역 설정 및 팔로우 버튼 추가

### DIFF
--- a/src/auth/Login.tsx
+++ b/src/auth/Login.tsx
@@ -1,12 +1,14 @@
 import { useForm, SubmitHandler } from 'react-hook-form';
 import axios from 'axios';
 import useLocalStorage from './useLocalStorage';
-import { useToken } from '../contexts/TokenProvider';
+import { useToken, useUserId } from '../contexts/TokenProvider';
 import { useNavigate } from 'react-router-dom';
 import { IToken } from '../types/token';
 import { IAuth } from '../types/auth';
+import { IUserId } from '../types/useId';
 
 const TOKEN_KEY = 'token';
+const USERID_KEY = 'userId';
 
 const Login = () => {
   const {
@@ -16,7 +18,9 @@ const Login = () => {
     formState: { isSubmitting, errors },
   } = useForm<IAuth>();
   const [, setValue] = useLocalStorage(TOKEN_KEY, '');
+  const [, setUserId] = useLocalStorage(USERID_KEY, '');
   const tokenContextObj: IToken | null = useToken();
+  const userIdContext: IUserId | null = useUserId();
 
   const navigate = useNavigate();
 
@@ -28,7 +32,9 @@ const Login = () => {
       })
       .then((res) => {
         setValue(res.data.token);
+        setUserId(res.data.user._id);
         tokenContextObj?.addToken(res.data.token);
+        userIdContext?.addUserId(res.data.user._id);
         navigate('/');
       })
       .catch(() => {

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -1,18 +1,24 @@
 import useLocalStorage from './useLocalStorage';
-import { useToken } from '../contexts/TokenProvider';
+import { useToken, useUserId } from '../contexts/TokenProvider';
 import { useNavigate } from 'react-router-dom';
 import { IToken } from '../types/token';
+import { IUserId } from '../types/useId';
 
 const TOKEN_KEY = 'token';
+const USERID_KEY = 'userId';
 
 const Logout = () => {
   const [, , removeValue] = useLocalStorage(TOKEN_KEY, '');
+  const [, , removeUserId] = useLocalStorage(USERID_KEY, '');
   const tokenContextObj: IToken | null = useToken();
+  const userIdContext: IUserId | null = useUserId();
   const navigate = useNavigate();
 
   const useLogout = () => {
     removeValue();
+    removeUserId();
     tokenContextObj?.removeToken();
+    userIdContext?.removeUserId();
     navigate('/');
   };
 

--- a/src/contexts/TokenProvider.tsx
+++ b/src/contexts/TokenProvider.tsx
@@ -1,21 +1,34 @@
 import React, { useState, createContext, useContext } from 'react';
 import useLocalStorage from '../auth/useLocalStorage';
 import { IToken } from '../types/token';
+import { IUserId } from '../types/useId';
 
 const TokenContext = createContext<IToken | null>(null);
+const UserIdContext = createContext<IUserId | null>(null);
 
 export const useToken = () => useContext(TokenContext);
+export const useUserId = () => useContext(UserIdContext);
 
 const TOKEN_KEY = 'token';
+const USERID_KEY = 'userId';
 
 const TokenProvider = ({ children }: { children: React.ReactNode }) => {
   const [localToken] = useLocalStorage(TOKEN_KEY, '');
+  const [localUserId] = useLocalStorage(USERID_KEY, '');
   const [token, setToken] = useState(localToken);
+  const [userId, setUserId] = useState(localUserId);
 
   const addToken = (getToken: string) => setToken(getToken);
   const removeToken = () => setToken(null);
 
-  return <TokenContext.Provider value={{ token, addToken, removeToken }}>{children}</TokenContext.Provider>;
+  const addUserId = (id: string) => setUserId(id);
+  const removeUserId = () => setUserId(null);
+
+  return (
+    <TokenContext.Provider value={{ token, addToken, removeToken }}>
+      <UserIdContext.Provider value={{ userId, addUserId, removeUserId }}>{children}</UserIdContext.Provider>
+    </TokenContext.Provider>
+  );
 };
 
 export default TokenProvider;

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,10 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { useUserId } from '../contexts/TokenProvider';
+import { IUserId } from '../types/useId';
 
 const Header = () => {
   const userLogin = localStorage.getItem('token');
+  const userIdContext: IUserId | null = useUserId();
+  const id = userIdContext?.userId;
   const navigate = useNavigate();
-  const handleMovePage = (page: string, id?: string) => {
+  const handleMovePage = (page: string, id?: string | null) => {
     id ? navigate(`/${page}/${id}`) : navigate(`/${page}`);
   };
 
@@ -17,7 +21,7 @@ const Header = () => {
           {userLogin ? (
             <>
               <button onClick={() => handleMovePage('notifications')}>알림</button>
-              <button onClick={() => handleMovePage('user')}>사용자</button>
+              <button onClick={() => handleMovePage('user', id)}>사용자</button>
             </>
           ) : (
             <>

--- a/src/types/useId.ts
+++ b/src/types/useId.ts
@@ -1,0 +1,5 @@
+export interface IUserId {
+  userId: string | null;
+  addUserId: (id: string) => void;
+  removeUserId: () => void;
+}

--- a/src/user/UserEdit.tsx
+++ b/src/user/UserEdit.tsx
@@ -3,12 +3,9 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import UserEditImg from './UserEditImg';
+import useMutation from '../api/useMutation';
 
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
-const TOKEN = localStorage.getItem('token');
-const headers = {
-  Authorization: `bearer ${TOKEN}`,
-};
 
 interface IFormValue {
   fullName: string;
@@ -17,6 +14,7 @@ interface IFormValue {
 
 const UserEdit = () => {
   const { id } = useParams();
+  const { mutate } = useMutation();
   const [imgFiles, setimgFiles] = useState({});
   const navigate = useNavigate();
 
@@ -44,26 +42,36 @@ const UserEdit = () => {
       }
     }
 
-    navigate(`/user/${id}`);
+    navigate(`/user/${id}`, { replace: true });
   };
 
   const getChangeImg = async (formdata: FormData) => {
-    await axios.post(`${API_URL}/users/upload-photo`, formdata, { headers });
+    return await mutate({
+      url: `${API_URL}/users/upload-photo`,
+      method: 'post',
+      data: formdata,
+    });
   };
 
   const getChangePassword = async (password: string) => {
-    return await axios.put(`${API_URL}/settings/update-password`, { password }, { headers });
+    return await mutate({
+      url: `${API_URL}/settings/update-password`,
+      method: 'put',
+      data: {
+        password,
+      },
+    });
   };
 
   const getChangeUserName = async (fullName: string) => {
-    return await axios.put(
-      `${API_URL}/settings/update-user`,
-      {
+    return await mutate({
+      url: `${API_URL}/settings/update-user`,
+      method: 'put',
+      data: {
         fullName,
         username: '',
       },
-      { headers }
-    );
+    });
   };
 
   return (

--- a/src/user/UserEditImg.tsx
+++ b/src/user/UserEditImg.tsx
@@ -4,7 +4,7 @@ import useAxios from '../api/useAxios';
 import { IUser } from '../types/user';
 
 const COVER_IMG_URL = 'https://ifh.cc/g/ZSypny.png';
-const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+const PROFIE_IMG_URL = 'https://ifh.cc/g/35RDD6.png';
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 interface IProps {
   id: string | undefined;

--- a/src/user/UserFollowers.tsx
+++ b/src/user/UserFollowers.tsx
@@ -5,7 +5,7 @@ import { IUser } from '../types/user';
 import Pagination from './Pagination';
 
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
-const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+const PROFIE_IMG_URL = 'https://ifh.cc/g/35RDD6.png';
 
 const UserFollowers = () => {
   const navigate = useNavigate();

--- a/src/user/UserFollowing.tsx
+++ b/src/user/UserFollowing.tsx
@@ -5,7 +5,7 @@ import { IUser } from '../types/user';
 import Pagination from './Pagination';
 
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
-const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+const PROFIE_IMG_URL = 'https://ifh.cc/g/35RDD6.png';
 
 const UserFollowing = () => {
   const navigate = useNavigate();

--- a/src/user/index.tsx
+++ b/src/user/index.tsx
@@ -26,12 +26,12 @@ const LIKE_IMG_URL = 'https://ifh.cc/g/vmscWK.png';
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 
 const User = () => {
-  const { id } = useParams();
+  const { id: currentPageId } = useParams();
   const userIdContext = useUserId();
   const myUserId = userIdContext?.userId;
   const navigate = useNavigate();
   const { data } = useAxios<IUser>({
-    url: `${API_URL}/users/${id}`,
+    url: `${API_URL}/users/${currentPageId}`,
     method: 'get',
   });
   const [userInfo, setUserInfo] = useState<IUserInfo>({
@@ -62,17 +62,16 @@ const User = () => {
   }, [data]);
 
   const handlemoveEditPage = () => {
-    navigate(`/userEdit/${id}`);
+    navigate(`/userEdit/${currentPageId}`);
   };
   const totalLikes =
     userInfo.posts && userInfo.posts.reduce((acc, cur: Pick<IPost, 'likes'>) => acc + cur.likes.length, 0);
 
-  const followbutton =
-    userFollow.followers && userFollow.followers.includes(myUserId as string) ? (
-      <button>팔로잉</button>
-    ) : (
-      <button>팔로우</button>
-    );
+  const followbutton = userFollow?.followers?.includes(myUserId as string) ? (
+    <button>팔로잉</button>
+  ) : (
+    <button>팔로우</button>
+  );
   return (
     <>
       <CoverImg src={userInfo.coverImage} />
@@ -82,7 +81,7 @@ const User = () => {
         <img src={LIKE_IMG_URL} />
         {totalLikes}
       </div>
-      {id === myUserId ? <button onClick={handlemoveEditPage}>내 정보 수정</button> : followbutton}
+      {currentPageId === myUserId ? <button onClick={handlemoveEditPage}>내 정보 수정</button> : followbutton}
 
       <Link to={`/followers`} state={{ followers: userFollow.followers }}>
         팔로워: {userFollow.followers && userFollow.followers.length}

--- a/src/user/index.tsx
+++ b/src/user/index.tsx
@@ -6,6 +6,7 @@ import useAxios from '../api/useAxios';
 import { IPost } from '../types/post';
 import { IFollow } from '../types/follow';
 import UserPosts from './UserPosts';
+import { useUserId } from '../contexts/TokenProvider';
 
 interface IUserInfo {
   fullName: string | undefined;
@@ -14,15 +15,22 @@ interface IUserInfo {
   coverImage: string;
 }
 
+interface IFollowList {
+  followers: string[];
+  following: string[];
+}
+
 const COVER_IMG_URL = 'https://ifh.cc/g/xBfBwB.png';
-const PROFIE_IMG_URL = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+const PROFIE_IMG_URL = 'https://ifh.cc/g/35RDD6.png';
 const LIKE_IMG_URL = 'https://ifh.cc/g/vmscWK.png';
 const API_URL = 'http://kdt.frontend.3rd.programmers.co.kr:5006';
 
 const User = () => {
   const { id } = useParams();
+  const userIdContext = useUserId();
+  const myUserId = userIdContext?.userId;
   const navigate = useNavigate();
-  const { data, fetchData } = useAxios<IUser>({
+  const { data } = useAxios<IUser>({
     url: `${API_URL}/users/${id}`,
     method: 'get',
   });
@@ -32,7 +40,7 @@ const User = () => {
     image: '',
     coverImage: '',
   });
-  const [userFollow, setUserFollow] = useState({
+  const [userFollow, setUserFollow] = useState<IFollowList>({
     followers: [],
     following: [],
   });
@@ -53,15 +61,18 @@ const User = () => {
     });
   }, [data]);
 
-  useEffect(() => {
-    fetchData();
-  }, []);
-
   const handlemoveEditPage = () => {
     navigate(`/userEdit/${id}`);
   };
   const totalLikes =
     userInfo.posts && userInfo.posts.reduce((acc, cur: Pick<IPost, 'likes'>) => acc + cur.likes.length, 0);
+
+  const followbutton =
+    userFollow.followers && userFollow.followers.includes(myUserId as string) ? (
+      <button>팔로잉</button>
+    ) : (
+      <button>팔로우</button>
+    );
   return (
     <>
       <CoverImg src={userInfo.coverImage} />
@@ -71,7 +82,7 @@ const User = () => {
         <img src={LIKE_IMG_URL} />
         {totalLikes}
       </div>
-      <button onClick={handlemoveEditPage}>내 정보 수정</button>
+      {id === myUserId ? <button onClick={handlemoveEditPage}>내 정보 수정</button> : followbutton}
 
       <Link to={`/followers`} state={{ followers: userFollow.followers }}>
         팔로워: {userFollow.followers && userFollow.followers.length}


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가

<br/>

## 📑 작업리스트

> 작업한 목록

- 로그인 시 userId 전역, 로컬에서 저장하도록 로직 추가
close #65 
- 전역에 저장된 id와 params로 들어온 id를 비교해서 내 정보 페이지면 내 정보 버튼을, 아니라면 해당 유저 팔로우 여부에 따라 팔로잉,팔로우 버튼이 보이도록 추가
- api 커스텀 훅 연결
- 프로필 기본 이미지 수정
close #47 

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항
- context api의 경우 기존 로직과 최대한 유사하게 추가하였습니다! 

### 로컬에서 확인하려면...
- 로컬에서 확인하기 위해서는 App에서 context api를 사용하기 위한 로직이 필요합니다.
```js
function App() {
  return (
    <TokenProvider>
...
    </TokenProvider>
  );
}
```
- `Router.tsx`에서 로그인 컴포넌트를 연결하여 로그인 후 유저 페이지에 접근해야 합니다.
- `useMutations.ts` 에서 토큰을 context api를 통해 호출하도록 해야합니다.
``` tsx
const useMutation = () => {
  const [error, setError] = useState<Error>();
  const tokenContext: IToken | null = useToken();

  const mutate = async ({ url, method, data }: IRequest) => {
    const config = {
      headers: {
        Authorization: `bearer ${tokenContext?.token}`,
        'Content-Type': data instanceof FormData ? 'multipart/form-data' : 'application/json',
      },
      data,
    };
...
}
```
이 부분을 수정하여 커밋할까 하다가 다른 분들의 로직과 충돌날까봐 일단 수정하지 않았습니다!! 

- 자잘하게 수정한 부분이 많아서 files changed 좀 많네요...><