### PR TITLE
feat:✨ 파일 업로드, 업데이트 시 사진의 용량을 제한함.

### DIFF
--- a/src/api/constValue.ts
+++ b/src/api/constValue.ts
@@ -1,0 +1,1 @@
+export const maxImageSize = 5 * 1024 * 1024 + 1;

--- a/src/post/CreatePost.tsx
+++ b/src/post/CreatePost.tsx
@@ -6,6 +6,7 @@ import useMutation from '../api/useMutation';
 import { Button } from '../common';
 import { END_POINT } from '../api/apiAddress';
 import Loading from '../api/Loading';
+import { maxImageSize } from '../api/constValue';
 
 export interface ILoading {
   isLoading: boolean;
@@ -93,9 +94,18 @@ function CreatePost() {
     });
   };
 
+  // updatePost에 있는 함수와 동일함. 추후에 파일로 따로 뺴면 좋을듯.
   const handleOnClickUploadImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.currentTarget.files) {
       const file = e.currentTarget.files[0];
+      const fileSize = file.size;
+
+      if (fileSize > maxImageSize) {
+        e.currentTarget.value = '';
+        setImage({});
+        setPreviewImage('');
+        return alert('첨부파일 사이즈는 5MB 이내로 등로 가능합니다.');
+      }
 
       const reader = new FileReader();
       reader.readAsDataURL(file);

--- a/src/post/CreatePost.tsx
+++ b/src/post/CreatePost.tsx
@@ -104,7 +104,7 @@ function CreatePost() {
         e.currentTarget.value = '';
         setImage({});
         setPreviewImage('');
-        return alert('첨부파일 사이즈는 5MB 이내로 등로 가능합니다.');
+        return alert('첨부파일 사이즈는 5MB 이내로 등록 가능합니다.');
       }
 
       const reader = new FileReader();

--- a/src/post/UpdatePost.tsx
+++ b/src/post/UpdatePost.tsx
@@ -9,6 +9,7 @@ import { END_POINT } from '../api/apiAddress';
 import axios from 'axios';
 import Loading from '../api/Loading';
 import { ILoading } from './CreatePost';
+import { maxImageSize } from '../api/constValue';
 
 const UpdatePost = () => {
   const [title, setTitle] = useState('');
@@ -103,9 +104,18 @@ const UpdatePost = () => {
     }
   };
 
+  // CreatePost에 있는 함수와 동일함. 추후에 파일로 따로 뺴면 좋을듯.
   const handleOnClickUploadImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.currentTarget.files) {
       const file = e.currentTarget.files[0];
+      const fileSize = file.size;
+
+      if (fileSize > maxImageSize) {
+        e.currentTarget.value = '';
+        setImage({});
+        setPreviewImage('');
+        return alert('첨부파일 사이즈는 5MB 이내로 등로 가능합니다.');
+      }
 
       const reader = new FileReader();
       reader.readAsDataURL(file);

--- a/src/post/UpdatePost.tsx
+++ b/src/post/UpdatePost.tsx
@@ -114,7 +114,7 @@ const UpdatePost = () => {
         e.currentTarget.value = '';
         setImage({});
         setPreviewImage('');
-        return alert('첨부파일 사이즈는 5MB 이내로 등로 가능합니다.');
+        return alert('첨부파일 사이즈는 5MB 이내로 등록 가능합니다.');
       }
 
       const reader = new FileReader();


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가


<br/>

## 📑 작업리스트

> 작업한 목록
#155 

- 파일 업로드 시 파일의 크기를 5mb로 제한합니다.

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항
