### PR TITLE
Refactor/search: 모바일 버전 페이지네이션 제거 및 검색페이지와 리스트 페이지 이동 시 초기화 문제 해결 등

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -15,7 +15,6 @@ import Header from './layout/Header';
 import ErrorBoundary from './api/ErrorBoundary';
 import NotFound from './NotFound';
 import ScrollToTop from './common/Scroll';
-import InfiniteScroll from './InfiniteScroll';
 
 function Router() {
   return (
@@ -37,7 +36,6 @@ function Router() {
             <Route path='/post/create/:channelId' element={<CreatePost />} />
             <Route path='/channel/:channelId' element={<Search />} />
             <Route path='/userEdit/:id' element={<UserEdit />} />
-            <Route path='/infinite' element={<InfiniteScroll />} />
             <Route path='/search/:channelId' element={<Search />} />
           </Route>
           <Route path='/*' element={<NotFound />} />

--- a/src/search/Index.tsx
+++ b/src/search/Index.tsx
@@ -4,7 +4,7 @@ import MostLikesPosts from './MostLikesPosts';
 import { useState, useEffect } from 'react';
 import ErrorBoundary from '../api/ErrorBoundary';
 import axios from 'axios';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import Loading from '../api/Loading';
 import { useQuery } from 'react-query';
 import { END_POINT } from '../api/apiAddress';
@@ -15,7 +15,7 @@ const Search = () => {
   const [specificPostData, setSpecificPostData] = useState([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { channelId } = useParams();
-
+  const pathname = useLocation().pathname;
   // 캐싱 안되게끔.
   const { data: totalPostData, isLoading: totalPostDataLoading } = useQuery(
     'totalPostData',
@@ -34,12 +34,16 @@ const Search = () => {
       axios.get(`${END_POINT}/posts/channel/${channelId}`).then((response) => {
         const { data } = response;
         setSpecificPostData(data);
+        setInputSearchValue('');
+        setSelectedSearchOption('제목');
         setIsLoading(false);
       });
     } else {
       axios.get(`${END_POINT}/posts`).then((response) => {
         const { data } = response;
         setSpecificPostData(data);
+        setInputSearchValue('');
+        setSelectedSearchOption('제목');
         setIsLoading(false);
       });
     }
@@ -47,7 +51,7 @@ const Search = () => {
 
   useEffect(() => {
     channelId && getSpecificPostsList();
-  }, [channelId]);
+  }, [channelId, pathname]);
 
   const loading = channelId ? isLoading : totalPostDataLoading;
   const postsInfo = channelId ? specificPostData : totalPostData;

--- a/src/search/Index.tsx
+++ b/src/search/Index.tsx
@@ -14,6 +14,7 @@ const Search = () => {
   const [inputSearchValue, setInputSearchValue] = useState('');
   const [specificPostData, setSpecificPostData] = useState([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isMobileSearching, setIsMobileSearching] = useState<boolean>(true);
   const { channelId } = useParams();
   const pathname = useLocation().pathname;
   // 캐싱 안되게끔.
@@ -37,6 +38,7 @@ const Search = () => {
         setInputSearchValue('');
         setSelectedSearchOption('제목');
         setIsLoading(false);
+        setIsMobileSearching(true);
       });
     } else {
       axios.get(`${END_POINT}/posts`).then((response) => {
@@ -45,6 +47,7 @@ const Search = () => {
         setInputSearchValue('');
         setSelectedSearchOption('제목');
         setIsLoading(false);
+        setIsMobileSearching(true);
       });
     }
   };
@@ -67,12 +70,14 @@ const Search = () => {
             setSelectedSearchOption={setSelectedSearchOption}
             setInputSearchValue={setInputSearchValue}
             currentChannelId={channelId}
+            setIsMobileSearching={setIsMobileSearching}
           />
           <PostListContainer
             postsInfo={postsInfo}
             selectedSearchOption={selectedSearchOption}
             inputSearchValue={inputSearchValue}
             currentChannelId={channelId}
+            isMobileSearching={isMobileSearching}
           />
         </>
       )}

--- a/src/search/PostList.tsx
+++ b/src/search/PostList.tsx
@@ -1,10 +1,14 @@
 import styled from 'styled-components';
 import { IsJsonString } from './isJsonString';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useToken } from '../contexts/TokenProvider';
 import { Avatar } from '../common';
-import theme from '../styles/theme';
+import { useState } from 'react';
 
+interface IMobile {
+  isMobileSearching: boolean;
+  pathName: string;
+}
 interface Ilikes {
   _id: string;
 }
@@ -38,6 +42,7 @@ interface IpostListProps {
   inputSearchValue: string;
   currentChannelId: string | undefined;
   channelName?: string;
+  isMobileSearching: boolean;
 }
 
 const Span = styled.span`
@@ -51,8 +56,10 @@ const PostList = ({
   inputSearchValue,
   currentChannelId,
   channelName,
+  isMobileSearching,
 }: IpostListProps) => {
   const navigatePost = useNavigate();
+  const pathName = useLocation().pathname;
 
   const selectPostsChannelTitle = (channelId: string | undefined) => {
     let PostsChannelTitle = '';
@@ -110,7 +117,7 @@ const PostList = ({
   const token = tokenObject?.token;
 
   return (
-    <WholeWrapper>
+    <WholeWrapper isMobileSearching={isMobileSearching} pathName={pathName}>
       <div className='postListTitle'>📃{selectPostsChannelTitle(currentChannelId)}</div>
       <PostListWrapper>
         {filteredPostsInfo.map((postInfo) => {
@@ -181,8 +188,8 @@ const PostList = ({
 };
 export default PostList;
 
-const WholeWrapper = styled.div`
-  display: flex;
+const WholeWrapper = styled.div<IMobile>`
+  display: ${(props) => `${props.pathName.includes('search') && props.isMobileSearching ? 'none' : 'flex'}`};
   flex-direction: column;
   margin-right: 2.5rem;
 

--- a/src/search/PostListContainer.tsx
+++ b/src/search/PostListContainer.tsx
@@ -8,6 +8,9 @@ import { IChannel } from '../types/channel';
 import { useToken } from '../contexts/TokenProvider';
 import { IComment } from '../types/comment';
 
+interface IInnerWidth {
+  innerWidth: number;
+}
 interface Ilikes {
   _id: string;
 }
@@ -45,6 +48,7 @@ const PostListContainer = ({
   const limit = 6;
   const offset = (page - 1) * limit;
   const navigate = useNavigate();
+  const innerWidth = window.innerWidth;
 
   useEffect(() => {
     setCheckedSorting(true);
@@ -122,13 +126,13 @@ const PostListContainer = ({
         ) : null}
       </ButtonContainer>
       <PostList
-        filteredPostsInfo={dividePosts(filterPosts())}
+        filteredPostsInfo={innerWidth > 600 ? dividePosts(filterPosts()) : filterPosts()}
         selectedSearchOption={selectedSearchOption}
         inputSearchValue={inputSearchValue}
         currentChannelId={currentChannelId}
         channelName={channelName}
       />
-      <PaginationContainer>
+      <PaginationContainer innerWidth={innerWidth}>
         <Pagination
           limit={limit}
           page={page}
@@ -197,6 +201,9 @@ const ButtonContainer = styled.div`
   }
 `;
 
-const PaginationContainer = styled.div`
+const PaginationContainer = styled.div<IInnerWidth>`
   position: relative;
+  display: ${(props) => {
+    return `${props.innerWidth > 600 ? 'block' : 'none'}`;
+  }};
 `;

--- a/src/search/PostListContainer.tsx
+++ b/src/search/PostListContainer.tsx
@@ -35,6 +35,7 @@ interface IpostListContainerProps {
   selectedSearchOption: string;
   inputSearchValue: string;
   currentChannelId: string | undefined;
+  isMobileSearching: boolean;
 }
 
 const PostListContainer = ({
@@ -42,6 +43,7 @@ const PostListContainer = ({
   selectedSearchOption,
   inputSearchValue,
   currentChannelId,
+  isMobileSearching,
 }: IpostListContainerProps) => {
   const [page, setPage] = useState(1);
   const [checkedSorting, setCheckedSorting] = useState(true);
@@ -131,6 +133,7 @@ const PostListContainer = ({
         inputSearchValue={inputSearchValue}
         currentChannelId={currentChannelId}
         channelName={channelName}
+        isMobileSearching={isMobileSearching}
       />
       <PaginationContainer innerWidth={innerWidth}>
         <Pagination

--- a/src/search/SearchBox.tsx
+++ b/src/search/SearchBox.tsx
@@ -8,10 +8,16 @@ interface IPathname {
 interface IsearchBoxProps {
   setSelectedSearchOption: (value: string) => void;
   setInputSearchValue: (value: string) => void;
+  setIsMobileSearching: (value: boolean) => void;
   currentChannelId: string | undefined;
 }
 
-const SearchBox = ({ setSelectedSearchOption, setInputSearchValue, currentChannelId }: IsearchBoxProps) => {
+const SearchBox = ({
+  setSelectedSearchOption,
+  setInputSearchValue,
+  setIsMobileSearching,
+  currentChannelId,
+}: IsearchBoxProps) => {
   const [inputValue, setInputValue] = useState('');
   const [selectedOption, setSelectedOption] = useState('제목');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -34,6 +40,7 @@ const SearchBox = ({ setSelectedSearchOption, setInputSearchValue, currentChanne
       e.preventDefault();
       setSelectedSearchOption(selectedOption);
       setInputSearchValue(inputValue);
+      setIsMobileSearching(false);
     },
     [inputValue, selectedOption, currentChannelId]
   );


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가
- 스타일 속성 변경

<br/>

## 📑 작업리스트

> 작업한 목록

-  모바일 버전 페이지네이션 제건
- 검색페이지와 리스트 페이지 이동 시 초기화 설정
- 검색페이지에서 검색한 경우에만 포스트 리스트 나오도록 변경 및 초기화

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항
- 아직 무한 스크롤은 적용하지 못했습니다.