### PR TITLE
fix: 로그인, 회원가입 페이지 라우터 위치 수정

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -21,9 +21,9 @@ function Router() {
       <ScrollToTop />
       <ErrorBoundary>
         <Routes>
+          <Route path='/signup' element={<SignUp />} />
+          <Route path='/login' element={<Login />} />
           <Route element={<Layout />}>
-            <Route path='/signup' element={<SignUp />} />
-            <Route path='/login' element={<Login />} />
             <Route path='/' element={<Post />} />
             <Route path='/notifications' element={<NotificationList />} />
             <Route path='/user/:id' element={<User />} />


### PR DESCRIPTION
## 📘 작업 유형

- 버그 수정

<br/>

## 📑 작업리스트

> 작업한 목록

- 회원가입, 로그인 페이지 채널목록 및 헤더 위치 버그 수정

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항

배포 사이트 보다가 회원가입이랑 로그인 페이지에서 데스크탑에선 채널이 안보여야하는데 보이고 헤더 위치가 이상한 버그가 있었습니다. 확인해보니 머지하면서 라우터 위치가 수정되면서 생긴 문제인 것 같아요~ 
라우터 위치만 수정했습니다!